### PR TITLE
feat: implementation of DID authentication

### DIFF
--- a/pkg/vc/command_test.go
+++ b/pkg/vc/command_test.go
@@ -6,12 +6,40 @@ import (
 	"fmt"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"
+	didtypes "github.com/medibloc/panacea-core/v2/x/did/types"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/hyperledger/aries-framework-go/pkg/crypto/primitive/bbs12381g2pub"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDIDAuthentication_Success(t *testing.T) {
+	holderPrivKey, err := btcec.NewPrivateKey(btcec.S256())
+	require.NoError(t, err)
+
+	mockVDR := NewMockVDR(holderPrivKey.PubKey().SerializeUncompressed(), "EcdsaSecp256k1VerificationKey2019")
+	f, err := NewFramework(mockVDR)
+	require.NoError(t, err)
+
+	holderDID := didtypes.NewDID(holderPrivKey.PubKey().SerializeCompressed())
+
+	proofOpts := &ProofOptions{
+		Controller:         holderDID,
+		VerificationMethod: fmt.Sprintf("%s#key1", holderDID),
+		SignatureType:      "EcdsaSecp256k1Signature2019",
+		Domain:             "https://my-domain.com",
+		Challenge:          "this is a challenge",
+		Created:            "2017-06-18T21:19:10Z",
+		ProofPurpose:       "authentication",
+	}
+
+	didAuth, err := f.AuthenticateDID(holderPrivKey.Serialize(), proofOpts)
+	require.NoError(t, err)
+
+	_, err = f.VerifyPresentation(didAuth)
+	require.NoError(t, err)
+}
 
 func TestFullScenarioWithSecp256k1(t *testing.T) {
 	cred := `{"@context": ["https://www.w3.org/2018/credentials/v1","https://www.w3.org/2018/credentials/examples/v1"],
@@ -229,30 +257,36 @@ func TestFullScenarioWithBBS(t *testing.T) {
 type MockVDR struct {
 	pubKeyBz   []byte
 	pubKeyType string
+	did        string
 }
 
 func NewMockVDR(pubKeyBz []byte, pubKeyType string) *MockVDR {
 	return &MockVDR{
 		pubKeyBz:   pubKeyBz,
 		pubKeyType: pubKeyType,
+		did:        didtypes.NewDID(pubKeyBz),
 	}
 }
 
 func (v *MockVDR) Resolve(didID string, _ ...vdr.DIDMethodOption) (*did.DocResolution, error) {
-	signingKey := did.VerificationMethod{
-		ID:         didID + "#key1",
-		Type:       v.pubKeyType,
-		Controller: didID,
-		Value:      v.pubKeyBz,
-	}
+	if didID == v.did {
+		signingKey := did.VerificationMethod{
+			ID:         didID + "#key1",
+			Type:       v.pubKeyType,
+			Controller: didID,
+			Value:      v.pubKeyBz,
+		}
 
-	return &did.DocResolution{
-		DIDDocument: &did.Doc{
-			Context:            []string{"https://w3id.org/did/v1"},
-			ID:                 didID,
-			VerificationMethod: []did.VerificationMethod{signingKey},
-		},
-	}, nil
+		return &did.DocResolution{
+			DIDDocument: &did.Doc{
+				Context:            []string{"https://w3id.org/did/v1"},
+				ID:                 didID,
+				VerificationMethod: []did.VerificationMethod{signingKey},
+			},
+		}, nil
+	} else {
+		return nil, fmt.Errorf("failed to resolve DID")
+	}
 }
 
 func (v *MockVDR) Create(_ string, _ *did.Doc, _ ...vdr.DIDMethodOption) (*did.DocResolution, error) {

--- a/pkg/vc/command_test.go
+++ b/pkg/vc/command_test.go
@@ -264,29 +264,24 @@ func NewMockVDR(pubKeyBz []byte, pubKeyType string) *MockVDR {
 	return &MockVDR{
 		pubKeyBz:   pubKeyBz,
 		pubKeyType: pubKeyType,
-		did:        didtypes.NewDID(pubKeyBz),
 	}
 }
 
 func (v *MockVDR) Resolve(didID string, _ ...vdr.DIDMethodOption) (*did.DocResolution, error) {
-	if didID == v.did {
-		signingKey := did.VerificationMethod{
-			ID:         didID + "#key1",
-			Type:       v.pubKeyType,
-			Controller: didID,
-			Value:      v.pubKeyBz,
-		}
-
-		return &did.DocResolution{
-			DIDDocument: &did.Doc{
-				Context:            []string{"https://w3id.org/did/v1"},
-				ID:                 didID,
-				VerificationMethod: []did.VerificationMethod{signingKey},
-			},
-		}, nil
-	} else {
-		return nil, fmt.Errorf("failed to resolve DID")
+	signingKey := did.VerificationMethod{
+		ID:         didID + "#key1",
+		Type:       v.pubKeyType,
+		Controller: didID,
+		Value:      v.pubKeyBz,
 	}
+
+	return &did.DocResolution{
+		DIDDocument: &did.Doc{
+			Context:            []string{"https://w3id.org/did/v1"},
+			ID:                 didID,
+			VerificationMethod: []did.VerificationMethod{signingKey},
+		},
+	}, nil
 }
 
 func (v *MockVDR) Create(_ string, _ *did.Doc, _ ...vdr.DIDMethodOption) (*did.DocResolution, error) {

--- a/pkg/vc/command_test.go
+++ b/pkg/vc/command_test.go
@@ -4,10 +4,11 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
+	"testing"
+
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"
 	didtypes "github.com/medibloc/panacea-core/v2/x/did/types"
-	"testing"
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/hyperledger/aries-framework-go/pkg/crypto/primitive/bbs12381g2pub"
@@ -257,7 +258,6 @@ func TestFullScenarioWithBBS(t *testing.T) {
 type MockVDR struct {
 	pubKeyBz   []byte
 	pubKeyType string
-	did        string
 }
 
 func NewMockVDR(pubKeyBz []byte, pubKeyType string) *MockVDR {

--- a/pkg/vdr/did_auth_test.go
+++ b/pkg/vdr/did_auth_test.go
@@ -1,0 +1,96 @@
+package vdr
+
+import (
+	"fmt"
+	didtypes "github.com/medibloc/panacea-core/v2/x/did/types"
+	"github.com/medibloc/vc-sdk/pkg/vc"
+	"github.com/mr-tron/base58"
+	"github.com/stretchr/testify/suite"
+	"github.com/tendermint/tendermint/crypto/secp256k1"
+	"testing"
+)
+
+type panaceaDIDAuthTestSuite struct {
+	suite.Suite
+
+	holderPrivKey   secp256k1.PrivKey
+	attackerPrivKey secp256k1.PrivKey
+
+	holderDID   string
+	attackerDID string
+
+	challenge string
+	domain    string
+
+	VDR *mockDIDClient
+}
+
+func TestPanaceaDIDAuthTestSuite(t *testing.T) {
+	suite.Run(t, &panaceaDIDAuthTestSuite{})
+}
+
+func (suite *panaceaDIDAuthTestSuite) BeforeTest(_, _ string) {
+	holderMnemonic, _ := newMnemonic()
+	attackerMnemonic, _ := newMnemonic()
+
+	suite.holderPrivKey, _ = generatePrivateKeyFromMnemonic(holderMnemonic)
+	suite.attackerPrivKey, _ = generatePrivateKeyFromMnemonic(attackerMnemonic)
+
+	suite.holderDID = didtypes.NewDID(suite.holderPrivKey.PubKey().Bytes())
+	suite.attackerDID = didtypes.NewDID(suite.attackerPrivKey.PubKey().Bytes())
+
+	holderPubKeyBase58 := base58.Encode(suite.holderPrivKey.PubKey().Bytes())
+	attackerPubKeyBase58 := base58.Encode(suite.attackerPrivKey.PubKey().Bytes())
+
+	holderDIDDoc := createDIDDoc(suite.holderDID, holderPubKeyBase58)
+	attackerDIDDoc := createDIDDoc(suite.attackerDID, attackerPubKeyBase58)
+
+	suite.VDR = newMockDIDClient(holderDIDDoc, attackerDIDDoc)
+
+	suite.challenge = "this is a challenge"
+	suite.domain = "https://my-domain.com"
+}
+
+func (suite *panaceaDIDAuthTestSuite) TestDIDAuthentication_Success() {
+	panaceaVDR := NewPanaceaVDR(suite.VDR)
+	f, err := vc.NewFramework(panaceaVDR)
+	suite.NoError(err)
+
+	proofOpts := &vc.ProofOptions{
+		Controller:         suite.holderDID,
+		VerificationMethod: fmt.Sprintf("%s#key1", suite.holderDID),
+		SignatureType:      ecdsaSigType,
+		Domain:             suite.domain,
+		Challenge:          suite.challenge,
+		Created:            "2017-06-18T21:19:10Z",
+		ProofPurpose:       "authentication",
+	}
+
+	didAuth, err := f.AuthenticateDID(suite.holderPrivKey.Bytes(), proofOpts)
+	suite.NoError(err)
+
+	_, err = f.VerifyPresentation(didAuth)
+	suite.NoError(err)
+}
+
+func (suite *panaceaDIDAuthTestSuite) TestDIDAuthentication_FailNotHolder() {
+	panaceaVDR := NewPanaceaVDR(suite.VDR)
+	f, err := vc.NewFramework(panaceaVDR)
+	suite.NoError(err)
+
+	proofOpts := &vc.ProofOptions{
+		Controller:         suite.holderDID,
+		VerificationMethod: fmt.Sprintf("%s#key1", suite.holderDID),
+		SignatureType:      ecdsaSigType,
+		Domain:             suite.domain,
+		Challenge:          suite.challenge,
+		Created:            "2017-06-18T21:19:10Z",
+		ProofPurpose:       "authentication",
+	}
+
+	didAuth, err := f.AuthenticateDID(suite.attackerPrivKey.Bytes(), proofOpts)
+	suite.NoError(err)
+
+	_, err = f.VerifyPresentation(didAuth)
+	suite.ErrorContains(err, "ecdsa: invalid signature")
+}


### PR DESCRIPTION
For DID authentication, an empty presentation with proof is used ([ref](https://w3c-ccg.github.io/vp-request-spec/#did-authentication)).
User can verify the DID auth by using the `VerifyPresentation`.